### PR TITLE
feat(SNC-06): create form to safe address of user

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,13 @@
       "name": "sana-coffee-delivery",
       "version": "0.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^3.9.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-hook-form": "^7.53.1",
         "react-router-dom": "^6.25.1",
-        "styled-components": "^6.1.12"
+        "styled-components": "^6.1.12",
+        "yup": "^1.4.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -490,6 +493,15 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.9.0.tgz",
+      "integrity": "sha512-bU0Gr4EepJ/EQsH/IwEzYLsT/PEj5C0ynLQ4m+GSHS+xKH4TfSelhluTgOaoc4kA5s7eCsQbM4wvZLzELmWzUg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2406,6 +2418,12 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2456,6 +2474,22 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.53.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.1.tgz",
+      "integrity": "sha512-6aiQeBda4zjcuaugWvim9WsGqisoUk+etmFEsSUMm451/Ic8L/UAb7sRtMj3V+Hdzm6mMjU1VhiSzYUZeBm0Vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-router": {
@@ -2718,6 +2752,12 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2729,6 +2769,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",
@@ -2924,6 +2970,30 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.4.0.tgz",
+      "integrity": "sha512-wPbgkJRCqIf+OHyiTBQoJiP5PFuAXaWiJK6AmYkzQAh5/c2K9hzSApBZG5wV9KoKSePF7sAxmNSvh/13YHkFDg==",
+      "license": "MIT",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/yup/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -11,10 +11,13 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.9.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.53.1",
     "react-router-dom": "^6.25.1",
-    "styled-components": "^6.1.12"
+    "styled-components": "^6.1.12",
+    "yup": "^1.4.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/src/components/InputLabelOpcional.tsx
+++ b/src/components/InputLabelOpcional.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const InputLabelOpcionalComponent = styled.p`
+  color: #9e9e9e;
+  font-size: 12px;
+`;
+
+export function InputLabelOpcional() {
+  return <InputLabelOpcionalComponent>Opcional</InputLabelOpcionalComponent>;
+}

--- a/src/components/InputRange.tsx
+++ b/src/components/InputRange.tsx
@@ -21,6 +21,7 @@ export function InputRange({ name, value, onChange }: InputRangeProps) {
   return (
     <InputRangeContainer>
       <InputRangeSubstractValue
+        type="button"
         onClick={() => {
           if (currentValue > 0) {
             setCurrentValue(currentValue - 1);
@@ -41,6 +42,7 @@ export function InputRange({ name, value, onChange }: InputRangeProps) {
         />
       </div>
       <InputRangeAddValue
+        type="button"
         onClick={() => {
           onChange(currentValue + 1);
           setCurrentValue(currentValue + 1);

--- a/src/components/InputTextError.tsx
+++ b/src/components/InputTextError.tsx
@@ -1,0 +1,17 @@
+import { FieldError, FieldErrorsImpl, Merge } from 'react-hook-form';
+import styled from 'styled-components';
+
+interface InputTextErrorProps {
+  error: FieldError | Merge<FieldError, FieldErrorsImpl<any>> | undefined;
+}
+
+const Label = styled.label`
+  color: red;
+  font-size: 12px;
+`;
+
+export function InputTextError({ error }: InputTextErrorProps) {
+  return (
+    <>{error && error.message && <Label>{error.message.toString()}</Label>}</>
+  );
+}

--- a/src/features/Cart/components/CarReviewItem.tsx
+++ b/src/features/Cart/components/CarReviewItem.tsx
@@ -51,8 +51,8 @@ export function CartReviewItem({
               }}
             />
             <ButtonIcon
+              type="button"
               label="Remover"
-              type="secondary"
               color={ColorType.SECONDARY_OUTLINED}
               pathImage="/IconThrashPurple.svg"
               onClick={() => {

--- a/src/features/Cart/components/CartAddress.tsx
+++ b/src/features/Cart/components/CartAddress.tsx
@@ -1,6 +1,5 @@
 import {
   CartAddressBody,
-  CartAddressForm,
   CartAddressHeader,
   CartAddressIcon,
   CartAddressPanel,
@@ -8,6 +7,7 @@ import {
   TitleAddressHeader,
   TitleCartReview,
 } from '../styles/CartAddressContainer';
+import { CartAddressForm } from './CartAddressForm';
 
 export function CartAddress() {
   return (
@@ -21,19 +21,11 @@ export function CartAddress() {
           <div>
             <TitleAddressHeader> Endereço de entrega </TitleAddressHeader>
             <DescriptionAddressHeader>
-              {' '}
-              Informe o endereço onde deseja receber seu pedido{' '}
+              Informe o endereço onde deseja receber seu pedido
             </DescriptionAddressHeader>
           </div>
         </CartAddressHeader>
-        <CartAddressForm>
-          <span> Field 1 </span>
-          <span> Field 2 </span>
-          <span> Field 3 </span>
-          <span> Field 4 </span>
-          <span> Field 5 </span>
-          <span> Field 6 </span>
-        </CartAddressForm>
+        <CartAddressForm />
       </CartAddressBody>
     </CartAddressPanel>
   );

--- a/src/features/Cart/components/CartAddressForm.tsx
+++ b/src/features/Cart/components/CartAddressForm.tsx
@@ -1,0 +1,103 @@
+import { useFormContext } from 'react-hook-form';
+import {
+  CartAddressFieldGroup,
+  CartAddressFieldRow,
+  CartAddressFormContainer,
+  InputText,
+} from '../styles/CartAddressFormContainer';
+import { InputTextError } from '@globalComponents/InputTextError';
+import { InputLabelOpcional } from '@globalComponents/InputLabelOpcional';
+
+export function CartAddressForm() {
+  const {
+    setValue,
+    register,
+    formState: { errors },
+  } = useFormContext();
+
+  const maskCEP = (value: string) => {
+    return value.replace(/\D/g, '').replace(/^(\d{5})(\d{3})+?$/, '$1-$2');
+  };
+
+  return (
+    <CartAddressFormContainer>
+      <CartAddressFieldRow>
+        <CartAddressFieldGroup>
+          <InputText
+            {...register('CEP')}
+            pattern="[0-9]{5}-[0-9]{3}"
+            id="txtCep"
+            type="text"
+            maxLength={9}
+            placeholder="CEP"
+            onChange={(event) => {
+              const formattedValue = maskCEP(event.target.value);
+              setValue('CEP', formattedValue);
+            }}
+          />
+          <InputTextError error={errors.CEP} />
+        </CartAddressFieldGroup>
+      </CartAddressFieldRow>
+      <CartAddressFieldRow>
+        <CartAddressFieldGroup>
+          <InputText
+            {...register('street')}
+            id="txtStreet"
+            type="text"
+            placeholder="Rua"
+          />
+          <InputTextError error={errors.street} />
+        </CartAddressFieldGroup>
+      </CartAddressFieldRow>
+      <CartAddressFieldRow>
+        <CartAddressFieldGroup>
+          <InputText
+            {...register('number')}
+            id="txtNumber"
+            type="number"
+            placeholder="Numero"
+          />
+          <InputTextError error={errors.number} />
+        </CartAddressFieldGroup>
+        <CartAddressFieldGroup>
+          <InputText
+            {...register('complement')}
+            id="txtComplement"
+            type="text"
+            placeholder="Complemento"
+          />
+          <InputLabelOpcional></InputLabelOpcional>
+        </CartAddressFieldGroup>
+      </CartAddressFieldRow>
+      <CartAddressFieldRow>
+        <CartAddressFieldGroup>
+          <InputText
+            {...register('neighborhood')}
+            id="txtNeighborhood"
+            type="text"
+            placeholder="Bairro"
+          />
+          <InputTextError error={errors.neighborhood} />
+        </CartAddressFieldGroup>
+        <CartAddressFieldGroup>
+          <InputText
+            {...register('city')}
+            id="txtCity"
+            type="text"
+            placeholder="Cidade"
+          />
+          <InputTextError error={errors.city} />
+        </CartAddressFieldGroup>
+        <CartAddressFieldGroup>
+          <InputText
+            {...register('state')}
+            id="txtState"
+            type="text"
+            placeholder="UF"
+          />
+          <InputTextError error={errors.state} />
+        </CartAddressFieldGroup>
+      </CartAddressFieldRow>
+    </CartAddressFormContainer>
+  );
+}

--- a/src/features/Cart/components/CartReview.tsx
+++ b/src/features/Cart/components/CartReview.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 
-import { ButtonContainer } from '@globalStyles/ButtonContainer';
 import { CartReviewDetails } from './CartReviewDetails';
 import { CartReviewListItem } from './CartReviewListItem';
 import { CartItem } from '@features/Cart/types/CartItem';
@@ -9,6 +8,7 @@ import {
   CartReviewPanel,
   TitleCartReview,
 } from '@features/Cart/styles/CartReviewContainer';
+import { ButtonContainer } from '@globalStyles/ButtonContainer';
 
 export function CartReview() {
   const [cartItens, setCartItens] = useState<CartItem[]>(cartItensMocked);
@@ -43,13 +43,7 @@ export function CartReview() {
           onDeleteItem={handleDeleteItem}
         />
         <CartReviewDetails items={cartItens} />
-        <ButtonContainer
-          disabled={totalCart <= 0}
-          /* Desenvolver a tela que mostra "Pedido realizado com sucesso" */
-          onClick={() => {
-            console.log('Chama a próxima tela');
-          }}
-        >
+        <ButtonContainer type="submit" disabled={totalCart <= 0}>
           CONFIRMAR PEDIDO
         </ButtonContainer>
       </CartReviewPanel>

--- a/src/features/Cart/page/CartPage.tsx
+++ b/src/features/Cart/page/CartPage.tsx
@@ -1,24 +1,44 @@
+import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+
 import { CartReview } from '@features/Cart/components/CartReview';
-import { CartAddress } from '../components/CartAddress';
+import { CartAddress } from '@features/Cart/components/CartAddress';
 import {
-  CartPageAddress,
+  CartPageDetails,
   CartPagePanel,
-  CartPagePayment,
-  CartPageProducts,
-} from '../styles/CartPageContainer';
+  CartPageProducts
+} from '@features/Cart/styles/CartPageContainer';
+import { cartAddressSchema } from '@features/Cart/schemas/cartAddressSchema';
+import { CartPersonAddress } from '@features/Cart/types/CartAddress';
 
 export function CartPage() {
+  const contextForms = useForm({
+    resolver: yupResolver(cartAddressSchema),
+  });
+
+  const onSubmitDelivery: SubmitHandler<CartPersonAddress> = (data) => {
+    console.log('Pedido realizado com sucesso: ', data);
+
+    const addressValues = contextForms.getValues();
+    console.log('Endereco: ', addressValues);
+  };
+
   return (
-    <CartPagePanel>
-      <CartPageAddress>
-        <CartAddress />
-      </CartPageAddress>
-      <CartPagePayment>
-        <p>Payment Section</p>
-      </CartPagePayment>
-      <CartPageProducts>
-        <CartReview />
-      </CartPageProducts>
-    </CartPagePanel>
+    <FormProvider {...contextForms}>
+      <CartPagePanel
+        onSubmit={(e) => {
+          e.preventDefault();
+          contextForms.handleSubmit(onSubmitDelivery)(e);
+        }}
+      >
+        <CartPageDetails>
+          <CartAddress />
+          <p>Payment Section</p>
+        </CartPageDetails>
+        <CartPageProducts>
+          <CartReview />
+        </CartPageProducts>
+      </CartPagePanel>
+    </FormProvider>
   );
 }

--- a/src/features/Cart/schemas/cartAddressSchema.ts
+++ b/src/features/Cart/schemas/cartAddressSchema.ts
@@ -1,0 +1,14 @@
+import { object, string } from 'yup';
+
+export const cartAddressSchema = object().shape({
+  
+  CEP: string()
+    .matches(/^\d{5}-\d{3}$/, 'CEP inválido')
+    .required('O CEP é obrigatório'),
+  street: string().required('A rua é obrigatória'),
+  number: string().required('O número é obrigatório'),
+  complement: string(),
+  neighborhood: string().required('O bairro é obrigatório'),
+  city: string().required('A cidade é obrigatória'),
+  state: string().required('O estado é obrigatório'),
+});

--- a/src/features/Cart/styles/CartAddressContainer.ts
+++ b/src/features/Cart/styles/CartAddressContainer.ts
@@ -5,7 +5,12 @@ export const CartAddressPanel = styled.div`
 `;
 
 export const CartAddressBody = styled.div`
+  margin-top: 15px;
   padding: 40px;
+
+  border-radius: 8px;
+
+  background: #f9f9f9;
 `;
 
 export const CartAddressHeader = styled.div`
@@ -16,8 +21,6 @@ export const CartAddressHeader = styled.div`
 export const CartAddressIcon = styled.div`
   margin-right: 8px;
 `;
-
-export const CartAddressForm = styled.div``;
 
 export const TitleCartReview = styled.p`
   font-family: 'Baloo 2', sans-serif;

--- a/src/features/Cart/styles/CartAddressFormContainer.ts
+++ b/src/features/Cart/styles/CartAddressFormContainer.ts
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+
+export const CartAddressFormContainer = styled.div`
+  width: 100%;
+`;
+
+export const CartAddressFieldRow = styled.div`
+  display: flex;
+  gap: 12px;
+  margin: 16px 0;
+`;
+
+export const CartAddressFieldGroup = styled.div`
+  width: 100%;
+`;
+
+export const InputText = styled.input.attrs((props) => ({
+  style: props.id === 'txtCep' ? { width: '200px' } : { width: '100%' },
+}))`
+  box-sizing: border-box;
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 12px;
+  gap: 4px;
+
+  width: 100%;
+  height: 42px;
+
+  background: #eeeded;
+  border: 1px solid #e6e5e5;
+  border-radius: 4px;
+
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 130%;
+`;
+
+export const InputTextError = styled.span``;

--- a/src/features/Cart/styles/CartPageContainer.ts
+++ b/src/features/Cart/styles/CartPageContainer.ts
@@ -1,32 +1,16 @@
 import styled from 'styled-components';
 
-export const CartPagePanel = styled.div`
+export const CartPagePanel = styled.form`
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: auto;
   gap: 32px;
   padding: 16px;
 `;
 
-export const CartPageAddress = styled.div`
-  grid-column: span 2;
-  grid-row: 1 span 2;
-
-  height: 372px;
-
-  border-radius: 6px;
-`;
-
-export const CartPagePayment = styled.div`
-  grid-column: span 2;
-  grid-row: 3;
-
-  height: 372px;
-
-  border-radius: 6px;
+export const CartPageDetails = styled.div`
+  grid-column: 1 / span 2;
 `;
 
 export const CartPageProducts = styled.div`
   grid-column: 3;
-  grid-row: span 3;
 `;

--- a/src/features/Cart/types/CartAddress.ts
+++ b/src/features/Cart/types/CartAddress.ts
@@ -1,0 +1,9 @@
+export type CartPersonAddress = {
+  CEP: string;
+  street: string;
+  number: string;
+  complement?: string | undefined;
+  neighborhood: string;
+  city: string;
+  state: string;
+};


### PR DESCRIPTION
Create form to safe address of user because the user needs to inform the
address to receive the product. The form has the fields: street, number,
complement, neighborhood, city, state and zip code.

For this commit, we need create components like InputLabelOpcional and
InputTextError to show information about status like error and optional.

We correct a bug inside of InputRange, because this component was not
followed with bottom type "button", for this reason, we added this type
because it submit a form every time I change the quantity in cart.

We added React Hook Forms and yup to validate the form.

Resolves: SNC-06-02